### PR TITLE
rdr3 specific patches

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -24,6 +24,19 @@ export class Main {
         return "https://runtime.fivem.net/doc/natives.json";
     }
   };
+
+  /**
+   * @param gametype
+   */
+  private static getNativeDocsUrl = (gametype: GamesType): string => {
+    switch (gametype) {
+      case GamesType.RDR3:
+        return "https://alloc8or.re/rdr3/nativedb/?n=";
+      default:
+        return "https://docs.fivem.net/natives/?_";
+    }
+  };
+
   /**
    * Startup logicNom de la native fivem
    *

--- a/main.ts
+++ b/main.ts
@@ -58,7 +58,8 @@ export class Main {
         files.init().then(async () => {
           files.category(json);
           await new Promise((resolve) => setTimeout(resolve, 1000));
-          const builder = new ContentGenerate(files);
+          const builder = new ContentGenerate(files)
+            .setDocumentationUrl(Main.getNativeDocsUrl(gametype));
           builder.generateTemplate(json);
         });
       });

--- a/src/content-generate.ts
+++ b/src/content-generate.ts
@@ -238,6 +238,9 @@ ${_function}
          */
         const jsonNative: NativeDefinition = data[category][native];
 
+        if ("comment" in jsonNative)
+          jsonNative["description"] = jsonNative["comment"];
+
         /**
          * Generation of the native name
          */

--- a/src/content-generate.ts
+++ b/src/content-generate.ts
@@ -241,6 +241,9 @@ ${_function}
         if ("comment" in jsonNative)
           jsonNative["description"] = jsonNative["comment"];
 
+        if ("return_type" in jsonNative)
+          jsonNative["results"] = jsonNative["return_type"];
+
         /**
          * Generation of the native name
          */

--- a/src/content-generate.ts
+++ b/src/content-generate.ts
@@ -360,7 +360,10 @@ ${_function}
 
       type = type.substring(0, type.length - 1);
 
-      if (this.isNonReturnPointerNative(data.name) || type === "char") {
+      if (type.startsWith("const "))
+        type = type.substring("const ".length);
+
+      if (this.isNonReturnPointerNative(data.name) || type.substring(-4) === "char") {
         params[i].type = type;
         continue;
       }

--- a/src/content-generate.ts
+++ b/src/content-generate.ts
@@ -261,7 +261,7 @@ ${_function}
         const functionTemplate = `function ${nativeName}(${nativeParams.params}) end`;
 
         this.generateDocs = this.template(
-          this.nativeDescription(jsonNative),
+          this.nativeDescription(jsonNative.description, native),
           nativeParams.luaDocs,
           ContentGenerate.ConvertNativeType(newReturnTypes),
           functionTemplate
@@ -431,10 +431,7 @@ ${_function}
    *
    * @return String Returns the description of the native or a prefect text indicating the lack of official description
    */
-  private nativeDescription = ({
-    description,
-    hash,
-  }: NativeDefinition): string => {
+  private nativeDescription = (description: string, hash: string): string => {
     let baseDesc = description
       ? description.replace(/^/gm, "---")
       : "---This native does not have an official description.";

--- a/src/content-generate.ts
+++ b/src/content-generate.ts
@@ -23,6 +23,11 @@ export class ContentGenerate {
   private generateDocs: string = "";
 
   /**
+   * Documentation url to append to each native description
+   */
+  private documentationUrl: string = "https://docs.fivem.net/natives/?_";
+
+  /**
    * Template to generate documentation and shortcuts for native speakers
    *
    * @param description
@@ -272,6 +277,16 @@ ${_function}
   };
 
   /**
+   * Set the documentation url to append to each native description
+   * @param url 
+   * @returns this
+   */
+  public setDocumentationUrl(url: string) {
+    this.documentationUrl = url;
+    return this;
+  }
+
+  /**
    * Array containing all natives that have pointers that aren't a return type
    */
   // I didn't know what else to name it
@@ -425,7 +440,7 @@ ${_function}
       : "---This native does not have an official description.";
 
     // Attach natives url;
-    baseDesc += `\n---[Native Documentation](https://docs.fivem.net/natives/?_${hash})`;
+    baseDesc += `\n---[Native Documentation](${this.documentationUrl}${hash})`;
 
     return baseDesc;
   };


### PR DESCRIPTION
Initially just wanted to fix the the link to the native docs for rdr3 
but came across some other issues.

Let me know if you need anything changed, these are mostly temporary fixes
that require a potentially large refactor to support them properly.

##### Changes

- use the `native` hash instead of the `hash` property for descriptions as it's not present in `alloc8or`'s structure (only as `gta_hash`?)

- overwrite `description` property if `comment` is present for `alloc8or`'s structure (had never type compile issue
when using dot notion, not 100% sure what happened here)

- add getter for the natives documentation link to use
- add setter within ContentGenerate class to set the docs link
